### PR TITLE
Build and install snap in GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+---
+name: Build
+on: push  # yamllint disable-line rule:truthy
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: snapcraft
+      - name: Install snap
+        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,6 @@
 ---
-name: Check code
-on: [push, pull_request]  # yamllint disable-line rule:truthy
+name: Check
+on: push  # yamllint disable-line rule:truthy
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build status](https://github.com/theengs/gateway-snap/workflows/Build/badge.svg)](https://github.com/theengs/gateway-snap/actions)
+[![Check status](https://github.com/theengs/gateway-snap/workflows/Check/badge.svg)](https://github.com/theengs/gateway-snap/actions)
+[![GitHub license](https://img.shields.io/github/theengs/gateway-snap.svg)](https://github.com/theengs/gateway-snap/blob/development/LICENSE)
 [![theengs-gateway](https://snapcraft.io/theengs-gateway/badge.svg)](https://snapcraft.io/theengs-gateway)
 
 # Theengs Gateway Snap


### PR DESCRIPTION
## Description:

This builds and installs the snap in a GitHub action and adds badges to the README.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
