### PR TITLE
Fix license badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://github.com/theengs/gateway-snap/workflows/Build/badge.svg)](https://github.com/theengs/gateway-snap/actions)
 [![Check status](https://github.com/theengs/gateway-snap/workflows/Check/badge.svg)](https://github.com/theengs/gateway-snap/actions)
-[![GitHub license](https://img.shields.io/github/theengs/gateway-snap.svg)](https://github.com/theengs/gateway-snap/blob/development/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/theengs/gateway-snap.svg)](https://github.com/theengs/gateway-snap/blob/development/LICENSE)
 [![theengs-gateway](https://snapcraft.io/theengs-gateway/badge.svg)](https://snapcraft.io/theengs-gateway)
 
 # Theengs Gateway Snap


### PR DESCRIPTION
## Description:

Fixes the license badge in the README

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
