### PR TITLE
CI: Check snap for errors with snap-review

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,5 +10,9 @@ jobs:
       - name: Build snap
         uses: snapcore/action-build@v1
         id: snapcraft
+      - name: Check snap for errors
+        run: |
+          sudo snap install review-tools
+          snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
         run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,5 +1,5 @@
 ---
-name: Check
+name: Checks
 on: push  # yamllint disable-line rule:truthy
 jobs:
   check:


### PR DESCRIPTION
## Description:

Add a step to the GitHub build workflow that checks the snap package for errors with snap-review. This is the same tool that is used by the Snap Store to vet snap packages before they're published.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
