### PR TITLE
Use architectures support in Snapcraft 7.1 for cross-compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           snapcraft-channel: 7.x/candidate
       - name: Archive logs as artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
         id: snapcraft
         with:
           snapcraft-channel: 7.x/candidate
+      - name: Archive logs as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: /home/runner/.cache/snapcraft/log/*.log
       - name: Check snap for errors
         run: |
           sudo snap install review-tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
       - name: Build snap
         uses: snapcore/action-build@v1
         id: snapcraft
+        with:
+          snapcraft-channel: 7.x/candidate
       - name: Check snap for errors
         run: |
           sudo snap install review-tools

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,8 +21,11 @@ confinement: strict
 base: core22
 architectures:
   - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+    build-for: amd64
+  - build-on: [amd64, arm64]
+    build-for: arm64
+  - build-on: [amd64, armhf]
+    build-for: armhf
 
 parts:
   theengs-gateway:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,8 +41,6 @@ parts:
       - python3-skbuild
     build-environment:
       - PARTS_PYTHON_VENV_ARGS: "--system-site-packages"
-    stage-packages:
-      - bluez  # Needed by Bleak for the bluetoothctl command
   scripts:
     plugin: dump
     source: scripts


### PR DESCRIPTION
## Description:

This uses architectures support in Snapcraft 7.1 (currently in the 7.x/candidate channel) to cross-compile the snap on amd64 for arm64 and armhf (https://github.com/snapcore/snapcraft/pull/3821).

This is currently failing, I'm investigating and reporting on https://forum.snapcraft.io/t/call-for-testing-snapcraft-7-1-0/30973.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
