### PR TITLE
Bump Theengs Gateway to v0.6.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,17 +21,13 @@ jobs:
           architecture: ${{ matrix.platform }}
           snapcraft-args: --verbose
         id: snapcraft
-      - name: Bind mount tmp directory to home
-        run: |
-          mkdir /home/runner/tmp
-          sudo mount --bind /tmp /home/runner/tmp/
-      - name: Check snap for errors
-        run: |
-          sudo snap install review-tools
-          snap-review ${{ steps.snapcraft.outputs.snap }}
-      - name: Install snap
-        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
-        if: matrix.platform == 'amd64'
+#      - name: Check snap for errors
+#        run: |
+#          sudo snap install review-tools
+#          snap-review ${{ steps.snapcraft.outputs.snap }}
+#      - name: Install snap
+#        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+#        if: matrix.platform == 'amd64'
       - name: Save snap as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
           architecture: ${{ matrix.platform }}
           snapcraft-args: --verbose
         id: snapcraft
-      - name: Check snap for errors
-        run: |
-          sudo snap install review-tools
-          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
+#      - name: Check snap for errors
+#        run: |
+#          sudo snap install review-tools
+#          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
         run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         if: matrix.platform == 'amd64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on: push  # yamllint disable-line rule:truthy
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         platform:
@@ -21,10 +21,10 @@ jobs:
           architecture: ${{ matrix.platform }}
           snapcraft-args: --verbose
         id: snapcraft
-#      - name: Check snap for errors
-#        run: |
-#          sudo snap install review-tools
-#          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
+      - name: Check snap for errors
+        run: |
+          sudo snap install review-tools
+          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
         run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         if: matrix.platform == 'amd64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Configure Qemu support
         uses: docker/setup-qemu-action@v2
       - name: Build snap
-        uses: diddlesnaps/snapcraft-multiarch-action@v1.5.0
+        uses: diddlesnaps/snapcraft-multiarch-action@v1.7.0
         with:
           architecture: ${{ matrix.platform }}
         id: snapcraft

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on: push  # yamllint disable-line rule:truthy
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform:
@@ -21,12 +21,16 @@ jobs:
           architecture: ${{ matrix.platform }}
           snapcraft-args: --verbose
         id: snapcraft
+      - name: Bind mount tmp directory to home
+        run: |
+          mkdir /home/runner/tmp
+          sudo mount --bind /tmp /home/runner/tmp/
       - name: Check snap for errors
         run: |
-          snap install review-tools
+          sudo snap install review-tools
           snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
-        run: snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         if: matrix.platform == 'amd64'
       - name: Save snap as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
         id: snapcraft
       - name: Check snap for errors
         run: |
-          sudo snap install review-tools
-          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
+          snap install review-tools
+          snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
-        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
+        run: snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         if: matrix.platform == 'amd64'
       - name: Save snap as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         uses: diddlesnaps/snapcraft-multiarch-action@v1.7.0
         with:
           architecture: ${{ matrix.platform }}
+          snapcraft-args: --verbose
         id: snapcraft
       - name: Check snap for errors
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check snap for errors
         run: |
           sudo snap install review-tools
-          snap-review ${{ steps.snapcraft.outputs.snap }}
+          sudo snap-review ${{ steps.snapcraft.outputs.snap }}
       - name: Install snap
         run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
         if: matrix.platform == 'amd64'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
     LYWSDCGQ, and Mi Flora. It translates these data into a readable JSON
     format and pushes those to an MQTT broker.
 icon: snap/local/logo-Theengs.png
-version: 0.6.0
+version: 0.6.5
 license: GPL-3.0
 contact: koen@vervloesem.eu
 website: https://github.com/theengs/gateway-snap
@@ -28,7 +28,7 @@ parts:
   theengs-gateway:
     plugin: python
     source: https://github.com/theengs/gateway.git
-    source-tag: v0.6.0
+    source-tag: v0.6.5
     override-pull: |
       craftctl default
       sed -i "s/version_tag/$SNAPCRAFT_PROJECT_VERSION/g" $CRAFT_PART_SRC/setup.py

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,9 @@ parts:
     build-packages:
       - build-essential
     python-packages:
+      - pip
+      - setuptools
+      - wheel
       - scikit-build
   scripts:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,12 +32,8 @@ parts:
     override-pull: |
       craftctl default
       sed -i "s/version_tag/$SNAPCRAFT_PROJECT_VERSION/g" $CRAFT_PART_SRC/setup.py
-      rm $SNAPCRAFT_PART_SRC/pyproject.toml  # Use pre-built system-site requirements
     build-packages:
       - build-essential
-      - python3-skbuild
-    build-environment:
-      - PARTS_PYTHON_VENV_ARGS: "--system-site-packages"
   scripts:
     plugin: dump
     source: scripts

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,8 +32,11 @@ parts:
     override-pull: |
       craftctl default
       sed -i "s/version_tag/$SNAPCRAFT_PROJECT_VERSION/g" $CRAFT_PART_SRC/setup.py
+      rm $SNAPCRAFT_PART_SRC/pyproject.toml  # Use pre-built system-site requirements
     build-packages:
       - build-essential
+    python-packages:
+      - scikit-build
   scripts:
     plugin: dump
     source: scripts

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,11 +35,13 @@ parts:
       rm $SNAPCRAFT_PART_SRC/pyproject.toml  # Use pre-built system-site requirements
     build-packages:
       - build-essential
-    python-packages:
+      - python3-skbuild     # Use scikit-build and setuptools from repo
+      - python3-setuptools  # as they are a combination that is known working
+    build-environment:
+      - PARTS_PYTHON_VENV_ARGS: "--system-site-packages"  # Use the above packages
+    python-packages:  # Replace default value [pip, setuptools, wheel]
       - pip
-      - setuptools
       - wheel
-      - scikit-build
   scripts:
     plugin: dump
     source: scripts


### PR DESCRIPTION
## Description:

Bumps Theengs Gateway in the snap to v0.6.5

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
