### PR TITLE
Add architecture badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Check status](https://github.com/theengs/gateway-snap/workflows/Check/badge.svg)](https://github.com/theengs/gateway-snap/actions)
 [![GitHub license](https://img.shields.io/github/license/theengs/gateway-snap.svg)](https://github.com/theengs/gateway-snap/blob/development/LICENSE)
 [![theengs-gateway](https://snapcraft.io/theengs-gateway/badge.svg)](https://snapcraft.io/theengs-gateway)
+![amd64](https://img.shields.io/badge/amd64-yes-green.svg)
+![arm64](https://img.shields.io/badge/arm64-yes-green.svg)
+![armhf](https://img.shields.io/badge/armhf-yes-green.svg)
 
 # Theengs Gateway Snap
 


### PR DESCRIPTION
## Description:

Add badges for the supported architectures to README file.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
