### PR TITLE
CI: Update deprecated upload-artifact v2 action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 #        run: sudo snap install --dangerous ${{ steps.snapcraft.outputs.snap }}
 #        if: matrix.platform == 'amd64'
       - name: Save snap as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}


### PR DESCRIPTION
## Description:

Update deprecated upload-artifact v2 action to v3

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
