### PR TITLE
Upgrade Theengs Gateway to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can show the snap's configuration with:
 ```shell
 $ snap get -d theengs-gateway
 {
+        "bindkeys": "",
         "ble": {
                 "adapter": "",
                 "scan-duration": 5,
@@ -57,8 +58,11 @@ $ snap get -d theengs-gateway
                 "discovery-topic": "homeassistant/sensor",
                 "hass-discovery": 1
         },
+        "identities": "",
         "log-level": "INFO",
         "mqtt": {
+                "enable-tls": 0,
+                "enable-ws": 0,
                 "host": "",
                 "pass": "",
                 "port": 1883,
@@ -91,4 +95,10 @@ After changing the configuration, Theengs Gateway should now run as a service. I
 
 ```shell
 snap start --enable theengs-gateway
+```
+
+Have a look at the snap's logs to troubleshoot problems:
+
+```shell
+snap logs theengs-gateway -f
 ```

--- a/scripts/bin/management-script
+++ b/scripts/bin/management-script
@@ -21,6 +21,10 @@ DEFAULT_PRESENCE_TOPIC="home/TheengsGateway/presence"
 DEFAULT_PRESENCE="0"
 DEFAULT_LWT_TOPIC="home/TheengsGateway/LWT"
 DEFAULT_PUBLISH_ADVDATA="0"
+DEFAULT_ENABLE_TLS="0"
+DEFAULT_ENABLE_WS="0"
+DEFAULT_BINDKEYS=""
+DEFAULT_IDENTITIES=""
 
 # ADAPTER
 adapter() {
@@ -502,4 +506,96 @@ previous_publish_advdata() {
 
 set_previous_publish_advdata() {
 	snapctl set private.mqtt.publish-advdata="$1"
+}
+
+# ENABLE_TLS
+enable_tls() {
+	enable_tls_enable="$(snapctl get mqtt.enable-tls)"
+	if [ -z "$enable_tls_enable" ]; then
+		enable_tls_enable="$DEFAULT_ENABLE_TLS"
+		set_enable_tls "$enable_tls_enable"
+		set_previous_enable_tls "$enable_tls_enable"
+	fi
+	echo "$enable_tls_enable"
+}
+
+set_enable_tls() {
+	snapctl set mqtt.enable-tls="$1"
+}
+
+previous_enable_tls() {
+	snapctl get private.mqtt.enable-tls
+}
+
+set_previous_enable_tls() {
+	snapctl set private.mqtt.enable-tls="$1"
+}
+
+# ENABLE_WS
+enable_ws() {
+	enable_ws_enable="$(snapctl get mqtt.enable-ws)"
+	if [ -z "$enable_ws_enable" ]; then
+		enable_ws_enable="$DEFAULT_ENABLE_WS"
+		set_enable_ws "$enable_ws_enable"
+		set_previous_enable_ws "$enable_ws_enable"
+	fi
+	echo "$enable_ws_enable"
+}
+
+set_enable_ws() {
+	snapctl set mqtt.enable-ws="$1"
+}
+
+previous_enable_ws() {
+	snapctl get private.mqtt.enable-ws
+}
+
+set_previous_enable_ws() {
+	snapctl set private.mqtt.enable-ws="$1"
+}
+
+# BINDKEYS
+bindkeys() {
+	bindkeys_addresses="$(snapctl get bindkeys)"
+	if [ -z "$bindkeys_addresses" ]; then
+		bindkeys_addresses="$DEFAULT_BINDKEYS"
+		set_bindkeys "$bindkeys_addresses"
+		set_previous_bindkeys "$bindkeys_addresses"
+	fi
+	echo "$bindkeys_addresses"
+}
+
+set_bindkeys() {
+	snapctl set bindkeys="$1"
+}
+
+previous_bindkeys() {
+	snapctl get private.bindkeys
+}
+
+set_previous_bindkeys() {
+	snapctl set private.bindkeys="$1"
+}
+
+# IDENTITIES
+identities() {
+	identities_addresses="$(snapctl get identities)"
+	if [ -z "$identities_addresses" ]; then
+		identities_addresses="$DEFAULT_IDENTITIES"
+		set_identities "$identities_addresses"
+		set_previous_identities "$identities_addresses"
+	fi
+	echo "$identities_addresses"
+}
+
+set_identities() {
+	snapctl set identities="$1"
+}
+
+previous_identities() {
+	snapctl get private.identities
+}
+
+set_previous_identities() {
+	snapctl set private.identities="$1"
 }

--- a/scripts/bin/theengs-gateway-wrapper
+++ b/scripts/bin/theengs-gateway-wrapper
@@ -44,5 +44,13 @@ LWT_TOPIC="$(lwt_topic)"
 export LWT_TOPIC
 PUBLISH_ADVDATA="$(publish_advdata)"
 export PUBLISH_ADVDATA
+ENABLE_TLS="$(enable_tls)"
+export ENABLE_TLS
+ENABLE_WS="$(enable_ws)"
+export ENABLE_WS
+BINDKEYS="$(bindkeys)"
+export BINDKEYS
+IDENTITIES="$(identities)"
+export IDENTITIES
 
-"$SNAP/bin/TheengsGateway" -H "$HOST" -P "$PORT" -u "$USER" -p "$PASS" -pt "$PUB_TOPIC" -st "$SUB_TOPIC" -sd "$SCAN_DUR" -tb "$TIME_BETWEEN" -ll "$LOG_LEVEL" -Dt "$DISCOVERY_TOPIC" -D "$DISCOVERY" -Dh "$HASS_DISCOVERY" -Dn "$DISCOVERY_DEVICE_NAME" -Df "$DISCOVERY_FILTER" -a "$ADAPTER" -ts "$TIME_SYNC" -tf "$TIME_FORMAT" -prt "$PRESENCE_TOPIC" -pr "$PRESENCE" -Lt "$LWT_TOPIC" -padv "$PUBLISH_ADVDATA"
+"$SNAP/bin/TheengsGateway" -H "$HOST" -P "$PORT" -u "$USER" -p "$PASS" -pt "$PUB_TOPIC" -st "$SUB_TOPIC" -sd "$SCAN_DUR" -tb "$TIME_BETWEEN" -ll "$LOG_LEVEL" -Dt "$DISCOVERY_TOPIC" -D "$DISCOVERY" -Dh "$HASS_DISCOVERY" -Dn "$DISCOVERY_DEVICE_NAME" -Df "$DISCOVERY_FILTER" -a "$ADAPTER" -ts "$TIME_SYNC" -tf "$TIME_FORMAT" -prt "$PRESENCE_TOPIC" -pr "$PRESENCE" -Lt "$LWT_TOPIC" -padv "$PUBLISH_ADVDATA" -tls "$ENABLE_TLS" -ws "$ENABLE_WS" -bk "$BINDKEYS" -id "$IDENTITIES"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -325,3 +325,63 @@ handle_publish_advdata_config() {
 	restart_gateway_if_running
 }
 handle_publish_advdata_config
+
+handle_enable_tls_config() {
+	enable_tls="$(enable_tls)"
+	previous_enable_tls="$(previous_enable_tls)"
+
+	if [ "$enable_tls" = "$previous_enable_tls" ]; then
+		return 0
+	fi
+
+	set_enable_tls "$enable_tls"
+	set_previous_enable_tls "$enable_tls"
+
+	restart_gateway_if_running
+}
+handle_enable_tls_config
+
+handle_enable_ws_config() {
+	enable_ws="$(enable_ws)"
+	previous_enable_ws="$(previous_enable_ws)"
+
+	if [ "$enable_ws" = "$previous_enable_ws" ]; then
+		return 0
+	fi
+
+	set_enable_ws "$enable_ws"
+	set_previous_enable_ws "$enable_ws"
+
+	restart_gateway_if_running
+}
+handle_enable_ws_config
+
+handle_bindkeys_config() {
+	bindkeys="$(bindkeys)"
+	previous_bindkeys="$(previous_bindkeys)"
+
+	if [ "$bindkeys" = "$previous_bindkeys" ]; then
+		return 0
+	fi
+
+	set_bindkeys "$bindkeys"
+	set_previous_bindkeys "$bindkeys"
+
+	restart_gateway_if_running
+}
+handle_bindkeys_config
+
+handle_identities_config() {
+	identities="$(identities)"
+	previous_identities="$(previous_identities)"
+
+	if [ "$identities" = "$previous_identities" ]; then
+		return 0
+	fi
+
+	set_identities "$identities"
+	set_previous_identities "$identities"
+
+	restart_gateway_if_running
+}
+handle_identities_config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
     LYWSDCGQ, and Mi Flora. It translates these data into a readable JSON
     format and pushes those to an MQTT broker.
 icon: snap/local/logo-Theengs.png
-version: 1.1.0
+version: 1.2.0
 license: GPL-3.0
 contact: koen@vervloesem.eu
 website: https://github.com/theengs/gateway-snap
@@ -28,16 +28,18 @@ parts:
   theengs-decoder:
     plugin: python
     source: https://github.com/theengs/decoder.git
-    source-tag: v1.5.0
+    source-tag: v1.6.4
+    source-subdir: python
     override-pull: |
       craftctl default
-      sed -i "s/version_tag/1.5.0/g" $CRAFT_PART_SRC/setup.py
-      sed -i "s/    shutil.rmtree('TheengsDecoder.egg-info')//g" $CRAFT_PART_SRC/setup.py
-      rm $SNAPCRAFT_PART_SRC/pyproject.toml  # Use pre-built system-site requirements
+      cd python
+      cp -r ../src .
+      rm pyproject.toml  # Use pre-built system-site requirements
     build-packages:
       - build-essential
-      - python3-skbuild     # Use scikit-build and setuptools from repo
-      - python3-setuptools  # as they are a combination that is known working
+      - python3-skbuild        # Use scikit-build
+      - python3-setuptools     # and setuptools from Ubuntu repository
+      - python3-setuptools-scm # as they are a combination that is known working
     build-environment:
       - PARTS_PYTHON_VENV_ARGS: "--system-site-packages"  # Use the above packages
     python-packages:  # Replace default value [pip, setuptools, wheel]
@@ -45,17 +47,17 @@ parts:
       - wheel
     stage:
       - lib/python3.10/site-packages/TheengsDecoder/*
-      - lib/python3.10/site-packages/TheengsDecoder-1.5.0.dist-info/*
   theengs-gateway:
     after:
       - theengs-decoder
     plugin: python
     source: https://github.com/theengs/gateway.git
-    source-tag: v1.1.0
+    source-tag: v1.2.0
     override-pull: |
       craftctl default
-      sed -i "s/version_tag/$SNAPCRAFT_PROJECT_VERSION/g" $CRAFT_PART_SRC/setup.py
-      sed -i 's/        "TheengsDecoder>=1.5.0",/"importlib_metadata",/g' $CRAFT_PART_SRC/setup.py
+      # Don't build Theengs Decoder as a dependency,
+      # as we've already built it in a separate part.
+      sed -i 's/        "TheengsDecoder>=[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*",//g' $CRAFT_PART_SRC/setup.py
   scripts:
     plugin: dump
     source: scripts


### PR DESCRIPTION
## Description:

Update to [Theengs Gateway v1.2.0](https://github.com/theengs/gateway/releases/tag/v1.2.0) with [Theengs Decoder v1.6.4](https://github.com/theengs/decoder/releases/tag/v1.6.4).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] I accept the [DCO](https://github.com/theengs/decoder/blob/development/docs/participate/development.md#developer-certificate-of-origin).
